### PR TITLE
feat: add queue position to response message

### DIFF
--- a/src/adapters/Database.re
+++ b/src/adapters/Database.re
@@ -284,20 +284,17 @@ let hasUnfinishedHelpItem = userId =>
     );
   });
 
-let getQueuePosition = userId =>
+let getQueuePosition = itemId =>
   Js.Promise.make((~resolve, ~reject as _reject) => {
-    Js.log2("USER_ID: ", userId);
     let conn = connect();
 
     let params =
-      MySql2.Params.named(
-        Json.Encode.(object_([("user_id", string(userId))])),
-      );
+      MySql2.Params.named(Json.Encode.(object_([("id", string(itemId))])));
 
     MySql2.execute(
       conn,
       "SELECT `id`,
-      (SELECT COUNT(*) FROM `help_items` WHERE `user_id` <= :user_id) AS `position`,
+      (SELECT COUNT(*) FROM `help_items` WHERE `id` <= :id) AS `position`,
       `user_id`,
       `description`,
       `room`,
@@ -305,7 +302,7 @@ let getQueuePosition = userId =>
       `time_created`,
       `time_closed`
       FROM `help_items`
-      WHERE `user_id` = :user_id AND finished = false LIMIT 1;",
+      WHERE `id` = :id AND finished = false LIMIT 1;",
       Some(params),
       res => {
         switch (res) {

--- a/src/adapters/Database.re
+++ b/src/adapters/Database.re
@@ -94,7 +94,7 @@ let addHelpItem = (userId, description, sendMessageWithAttachments) => {
 };
 
 let addRoom = (itemId, room) =>
-  Js.Promise.make((~resolve as _resolve, ~reject as _reject) => {
+  Js.Promise.make((~resolve, ~reject as _reject) => {
     let conn = connect();
 
     let params =
@@ -114,7 +114,7 @@ let addRoom = (itemId, room) =>
         | `Select(select) => Js.log2("SELECT: ", select)
         | `Mutation(mutation) =>
           Js.log2("MUTATION: ", mutation);
-          _resolve(. true);
+          resolve(. true);
         };
 
         MySql2.Connection.close(conn);

--- a/src/services/Help.re
+++ b/src/services/Help.re
@@ -25,7 +25,7 @@ let selectRoom = (selectedOption, itemId, sendMessage) =>
                 let msg =
                   switch (queuePosition) {
                   | Some(queueNum) =>
-                    "Ok, have a seat and relax. You’re number "
+                    "Ok, have a seat and relax. You're number "
                     ++ string_of_int(queueNum)
                     ++ " in line. :coffee:"
                   | None => "Oops. Couldn't get your position in queue."

--- a/src/services/Help.re
+++ b/src/services/Help.re
@@ -36,7 +36,10 @@ let selectRoom = (selectedOption, itemId, sendMessage) =>
                 resolve(queuePosition);
               })
            |> ignore :
-           sendMessage("Something went wrong. Try again later!") |> ignore;
+           sendMessage(
+             "I ran into some trouble adding your location. Try again later!",
+           )
+           |> ignore;
          resolve();
        })
     |> ignore

--- a/src/services/Help.re
+++ b/src/services/Help.re
@@ -20,14 +20,14 @@ let selectRoom = (selectedOption, itemId, sendMessage) =>
     Database.addRoom(int_of_string(itemId), List.hd(room))
     |> then_(roomWasAdded => {
          roomWasAdded ?
-           Database.getQueuePosition("Joakim1")
+           Database.getQueuePosition(itemId)
            |> then_(queuePosition => {
                 let msg =
                   switch (queuePosition) {
                   | Some(queueNum) =>
-                    "Ok, have a seat and relax. You’re number"
+                    "Ok, have a seat and relax. You’re number "
                     ++ string_of_int(queueNum)
-                    ++ "in line. :coffee:"
+                    ++ " in line. :coffee:"
                   | None => "Oops. Couldn't get your position in queue."
                   };
 

--- a/src/services/Help.re
+++ b/src/services/Help.re
@@ -33,7 +33,7 @@ let selectRoom = (selectedOption, itemId, sendMessage) =>
 
                 sendMessage(msg) |> ignore;
 
-                resolve();
+                resolve(queuePosition);
               })
            |> ignore :
            sendMessage("Something went wrong. Try again later!") |> ignore;

--- a/src/services/Help.re
+++ b/src/services/Help.re
@@ -1,24 +1,44 @@
-let mayday = (text, user, isAdmin, sendMessage, sendMessageWithAttachments) => {
-  Js.Promise.(
-    isAdmin ?
-      sendMessage("Hey, this is restricted to students!") |> ignore :
-      user
-      |> Database.hasUnfinishedHelpItem
-      |> then_(hasUnfinished => {
-           hasUnfinished ?
-             sendMessage("You're already on the help list!") |> ignore :
-             Database.addHelpItem(user, text, sendMessageWithAttachments);
+open Js.Promise;
 
-           resolve();
-         })
-      |> ignore
-  );
-};
+let mayday = (text, user, isAdmin, sendMessage, sendMessageWithAttachments) =>
+  isAdmin ?
+    sendMessage("Hey, this is restricted to students!") |> ignore :
+    user
+    |> Database.hasUnfinishedHelpItem
+    |> then_(hasUnfinished => {
+         hasUnfinished ?
+           sendMessage("You're already on the help list!") |> ignore :
+           Database.addHelpItem(user, text, sendMessageWithAttachments);
 
-let selectRoom = (selectOption, itemId, sendMessage) => {
-  switch (selectOption) {
+         resolve();
+       })
+    |> ignore;
+
+let selectRoom = (selectedOption, itemId, sendMessage) =>
+  switch (selectedOption) {
   | Some(room) =>
-    Database.addRoom(int_of_string(itemId), List.hd(room), sendMessage)
+    Database.addRoom(int_of_string(itemId), List.hd(room))
+    |> then_(roomWasAdded => {
+         roomWasAdded ?
+           Database.getQueuePosition("Joakim1")
+           |> then_(queuePosition => {
+                let msg =
+                  switch (queuePosition) {
+                  | Some(queueNum) =>
+                    "Ok, have a seat and relax. You’re number"
+                    ++ string_of_int(queueNum)
+                    ++ "in line. :coffee:"
+                  | None => "Oops. Couldn't get your position in queue."
+                  };
+
+                sendMessage(msg) |> ignore;
+
+                resolve();
+              })
+           |> ignore :
+           sendMessage("Something went wrong. Try again later!") |> ignore;
+         resolve();
+       })
+    |> ignore
   | None => ()
   };
-};

--- a/src/services/Queue.re
+++ b/src/services/Queue.re
@@ -1,4 +1,4 @@
-let clear = (isAdmin, sendMessage) => {
+let clear = (isAdmin, sendMessage) =>
   isAdmin ?
     Js.Promise.(
       Database.markAllAsFinished()
@@ -14,41 +14,37 @@ let clear = (isAdmin, sendMessage) => {
       |> ignore
     ) :
     sendMessage("Nice try! :face_with_hand_over_mouth:") |> ignore;
-};
 
-let next = (isAdmin, sendMessage, sendMessageWithAttachments) => {
+let next = (isAdmin, sendMessage, sendMessageWithAttachments) =>
   isAdmin ?
-    {
-      Js.Promise.(
-        Database.getFirstHelpItem()
-        |> then_(item => {
-             switch (item) {
-             | Some((helpItem: Database.helpItem)) =>
-               sendMessageWithAttachments(
-                 "Really remove "
-                 ++ Slack.Utils.encodeUserId(helpItem.userId)
-                 ++ " from the queue? Have they received help?",
-                 Slack.Message.confirmQueueRemoval(helpItem.id),
-               )
-               |> ignore
-             | None =>
-               "There's no one next in line! Nice work! :tada:"
-               |> sendMessage
-               |> ignore
-             };
-             resolve();
-           })
-        |> ignore
-      );
-    } :
+    Js.Promise.(
+      Database.getFirstHelpItem()
+      |> then_(item => {
+           switch (item) {
+           | Some((helpItem: Database.helpItem)) =>
+             sendMessageWithAttachments(
+               "Really remove "
+               ++ Slack.Utils.encodeUserId(helpItem.userId)
+               ++ " from the queue? Have they received help?",
+               Slack.Message.confirmQueueRemoval(helpItem.id),
+             )
+             |> ignore
+           | None =>
+             "There's no one next in line! Nice work! :tada:"
+             |> sendMessage
+             |> ignore
+           };
+           resolve();
+         })
+      |> ignore
+    ) :
     sendMessage("Hey, this is restricted to teachers! :face_with_monocle:")
     |> ignore;
-};
 
 let getOpenItems = sendMessage =>
   Database.getOpenItems(sendMessage) |> ignore;
 
-let markAsFinished = (itemId, sendMessage) => {
+let markAsFinished = (itemId, sendMessage) =>
   Js.Promise.(
     switch (itemId) {
     | Some(id) =>
@@ -88,4 +84,3 @@ let markAsFinished = (itemId, sendMessage) => {
     | None => ()
     }
   );
-};


### PR DESCRIPTION
**WIP**

Would be nice with some feedback here, as it's still a work in progress. As discussed earlier, the position prop on helpItem type is probably unnecessary, but I wanted to move the conversation here.

Responds with the users position in queue after selecting a room.

Delivers: https://waffle.io/chas-academy/drmayday/cards/5c40516c2e5d670436faaa8b

Closes #9